### PR TITLE
Remove 'link the group blog' from README todo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,3 @@ npm start
 - Insert news related to the group (2020)
 
 Check the issues for updated activities to be done.
-
-### Optional
-- Link the group blog at navbar


### PR DESCRIPTION
I think this was already done in PR #30 